### PR TITLE
Added `mix deps.get` instruction to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Validates data by evaluating each message and verifying that it has the required fields as specified by the [`SmartCity.Dataset.Technical.schema`](https://github.com/smartcitiesdata/smart_city_registry/blob/master/lib/smart_city/dataset/technical.ex) Valid messages will be produced to the next topic, and invalid or bad messages will be sent to a dead letter queue.
 
+### Setup
+
+  * Run `mix deps.get` to install dependencies
+
 ### To run the tests
 
   * Run `mix test` to run the tests a single time


### PR DESCRIPTION
When I cloned the valkyrie repository and ran `mix test` as stated in the README file, I received dependency errors and a hint to run `mix deps.get`.  Adding a Setup step to run `mix deps.get` prevent others from encountering this.